### PR TITLE
Bug/do not clean docs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 History
 =======
 
+## 0.0.6
+
+- Make the filter in `yesno.matching()` optional
+- Export GenericTest and Recording types
+- Improved test coverage and cross platform support
+
 ## 0.0.5
 
 - Various bug fixes

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "preversion": "npm run clean && npm run lint && npm run prettier && npm run tests",
     "version": "npm run compile && npm run docs",
-    "clean": "rimraf dist && rimraf docs",
+    "clean": "rimraf dist",
     "compile": "tsc",
     "watch": "npm run compile -- -w",
     "test": "npm run lint && npm run coverage",


### PR DESCRIPTION
Do not remove docs in the clean step. These are version controlled so should be preserved in the repo.

Currently this is preventing the `preversion` NPM step from passing.