### PR TITLE
Bug/proxy headers in spy mode

### DIFF
--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -223,7 +223,7 @@ export default class Interceptor extends EventEmitter implements IInterceptEvent
       const responseSerializer = new ResponseSerializer(proxiedResponse);
       debugReq('proxied response (%d)', proxiedResponse.statusCode);
       if (proxiedResponse.statusCode) {
-        interceptedResponse.writeHead(proxiedResponse.statusCode);
+        interceptedResponse.writeHead(proxiedResponse.statusCode, proxiedResponse.headers);
       }
       (readable as any).pipeline(proxiedResponse, responseSerializer, interceptedResponse);
 

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -22,12 +22,14 @@ export function start(port: number = PORT): Promise<ITestServer> {
   app.get('/get', ({ headers }: express.Request, res: express.Response) => {
     debug('Received GET request');
     res.status(headers['x-status-code'] ? parseInt(headers['x-status-code'] as string, 10) : 200);
+    res.setHeader('x-test-server-header', 'foo');
     res.send({ headers, method: 'GET', path: '/get' });
   });
 
   app.post('/post', ({ headers, body }: express.Request, res: express.Response) => {
     debug('Received POST request');
     res.status(headers['x-status-code'] ? parseInt(headers['x-status-code'] as string, 10) : 200);
+    res.setHeader('x-test-server-header', 'foo');
     res.send({ headers, body, method: 'POST', path: '/post' });
   });
 

--- a/test/unit/yesno.spec.ts
+++ b/test/unit/yesno.spec.ts
@@ -89,8 +89,34 @@ describe('Yesno', () => {
 
     it('should proxy status code', async () => {
       yesno.spy();
-      await expect(requestTestServer({ headers: { 'x-status-code': 500 } })).to.be.rejected;
-      expect(yesno.matching(/get/).response()).to.have.property('statusCode', 500);
+
+      const response = await rp({
+        headers: { 'x-status-code': 201 },
+        method: 'GET',
+        resolveWithFullResponse: true,
+        uri: 'http://localhost:3001/get',
+      });
+
+      // verify both the proxied and intercepted response
+      expect(response).to.have.property('statusCode', 201);
+      expect(yesno.matching(/get/).response()).to.have.property('statusCode', 201);
+    });
+
+    it('should proxy headers', async () => {
+      yesno.spy();
+
+      const response = await rp({
+        method: 'GET',
+        resolveWithFullResponse: true,
+        uri: 'http://localhost:3001/get',
+      });
+
+      // verify both the proxied and intercepted response
+      expect(response).to.have.nested.property('headers.x-test-server-header', 'foo');
+      expect(yesno.matching(/get/).response()).to.have.nested.property(
+        'headers.x-test-server-header',
+        'foo',
+      );
     });
 
     it('should support multipart/form-data', async () => {


### PR DESCRIPTION
Hey @ianwsperber! Hope all is well :)

I started using this awesome project and ran into a bug. When recording requests the response that is written to the file system contained headers, but the response sent back to the original HTTP request did not.