### PR TITLE
Fix bug where an incorrect content-length in server response caused t…

### DIFF
--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -174,6 +174,10 @@ export default class Interceptor extends EventEmitter implements IInterceptEvent
       throw new Error(`Missing client options for yesno req ${id}`);
     }
 
+    interceptedResponse.on('finish', () => {
+      debugReq('Response finished');
+    });
+
     const { clientOptions } = this.clientRequests[id];
     const clientRequest = this.clientRequests[id].clientRequest as ClientRequestFull;
     const isHttps: boolean = (interceptedRequest.connection as any).encrypted;
@@ -187,6 +191,8 @@ export default class Interceptor extends EventEmitter implements IInterceptEvent
     this.requestNumber++;
 
     debugReq('Emitting "intercept"');
+
+    // YesNo will listen for this event to mock the response
     this.emit('intercept', {
       clientRequest,
       comparatorFn: this.comparatorFn,

--- a/test/unit/mocks/mock-x-www-form-urlencoded.json
+++ b/test/unit/mocks/mock-x-www-form-urlencoded.json
@@ -1,0 +1,38 @@
+{
+  "records": [
+    {
+      "__duration": 0,
+      "__id": "3814c497-cded-4e4d-8dff-3fde6feebcc9",
+      "__timestamp": 1540332352920,
+      "__version": "1.0.0",
+      "request": {
+        "body": "email=example%40example.com&description=YesNo%20test",
+        "headers": {
+          "accept": "application/json",
+          "content-type": "application/x-www-form-urlencoded",
+          "content-length": 59,
+          "host": "example.com"
+        },
+        "host": "example.com",
+        "method": "POST",
+        "path": "/my/path",
+        "port": 443,
+        "protocol": "https"
+      },
+      "response": {
+        "body": {
+          "foo": "bar"
+        },
+        "headers": {
+          "server": "nginx",
+          "date": "Mon, 11 Mar 2019 15:58:15 GMT",
+          "content-type": "application/json",
+          "content-length": "999999999",
+          "connection": "keep-alive"
+        },
+        "statusCode": 200
+      },
+      "url": "https://example.com:443/my/path"
+    }
+  ]
+}

--- a/test/unit/yesno.spec.ts
+++ b/test/unit/yesno.spec.ts
@@ -275,6 +275,32 @@ describe('Yesno', () => {
       expect(response).to.eql('foobar');
       expect(yesno.intercepted()).to.have.lengthOf(1);
     });
+
+    it('should override the "content-length" header in the server response if incorrect', async () => {
+      const mocks = await yesno.load({ filename: `${mocksDir}/mock-x-www-form-urlencoded.json` });
+      const mockContentLength = mocks[0].response.headers['content-length'];
+      expect(mockContentLength).to.eql('999999999');
+
+      yesno.mock(mocks);
+
+      const response = await rp({
+        form: {
+          description: 'YesNo test',
+          email: 'example@example.com',
+        },
+        method: 'POST',
+        resolveWithFullResponse: true,
+        uri: 'https://example.com/my/path',
+      });
+
+      const intercepted = yesno.intercepted();
+      expect(intercepted).to.have.lengthOf(1);
+      const overriddenContentLength = response.headers['content-length'];
+      expect(overriddenContentLength).to.be.ok;
+      expect(overriddenContentLength, 'Had to override content length').to.not.eql(
+        mockContentLength,
+      );
+    });
   });
 
   describe('#recording', () => {


### PR DESCRIPTION
Fix bug where an incorrect content-length in server response caused timeouts. Not actually related to x-www-form-urlencoded.

"Incorrect" just because serializing & deserializing JSON may cause length to change.