### PR TITLE
Fix Failing Tests on Node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "io-ts": "^1.3.4",
     "io-ts-reporters": "0.0.21",
     "lodash": "^4.17.11",
-    "mitm": "^1.4.0",
+    "mitm": "^1.7.0",
     "readable-stream": "^3.0.6",
     "uuid": "^3.3.2",
     "yargs": "^12.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,10 +1766,10 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-mitm@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/mitm/-/mitm-1.4.0.tgz#ebb257fc5dc23ebbc0ac171634e4f790178b6a5b"
-  integrity sha512-N9a4X2q4umBtST4QT0BgTxdTkep5etjExhHGxXVO2jGEUbQCoqFX/7qYJ5t7njWOTvtuO0kSCbh455sSF6ySmQ==
+mitm@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/mitm/-/mitm-1.7.0.tgz#da03b8448090168bc68bcd847c6e014fde320829"
+  integrity sha512-O6EjnhSf7dDq+pveB5WlRbaz34cZgQuRfey7RonqsD2QB//eVXniYnH5u8QMB6bG7BUIJofL7UPaopE3iYkKlA==
   dependencies:
     semver ">= 5 < 6"
     underscore ">= 1.1.6 < 1.6"


### PR DESCRIPTION
This PR updates the mitm dependency to the latest version, which supports Node 10.15.1+.  More details here:

https://github.com/moll/node-mitm/issues/57