### PR TITLE
add test to show matching.respond can handle out of order mocks

### DIFF
--- a/test/unit/yesno.spec.ts
+++ b/test/unit/yesno.spec.ts
@@ -57,6 +57,30 @@ describe('Yesno', () => {
     });
   }
 
+  /**
+   * Make a mocked response
+   *
+   * @param options to override the default response values
+   */
+  function createMock(options: PartialDeep<IHttpMock> = {}): IHttpMock {
+    return _.merge(
+      {
+        request: {
+          host: 'localhost',
+          method: 'GET',
+          path: '/get',
+          port: 3001,
+          protocol: 'http',
+        },
+        response: {
+          body: 'foobar',
+          statusCode: 200,
+        },
+      },
+      options,
+    ) as IHttpMock;
+  }
+
   before(async () => {
     server = await testServer.start();
   });
@@ -155,24 +179,6 @@ describe('Yesno', () => {
   });
 
   describe('#mock', () => {
-    function createMock(options: PartialDeep<IHttpMock> = {}): IHttpMock {
-      return _.merge(
-        {
-          request: {
-            host: 'localhost',
-            method: 'GET',
-            path: '/get',
-            port: 3001,
-            protocol: 'http',
-          },
-          response: {
-            body: 'foobar',
-            statusCode: 200,
-          },
-        },
-        options,
-      ) as IHttpMock;
-    }
     beforeEach(async () => {
       await yesno.mock(await yesno.load({ filename: `${mocksDir}/mock-test-yesno.json` }));
     });
@@ -218,41 +224,6 @@ describe('Yesno', () => {
       expect(yesno.intercepted()).to.have.lengthOf(0);
       expect(await requestTestServer({ json: true })).to.eql({ foo: 'bar' });
       expect(yesno.intercepted()).to.have.lengthOf(1);
-    });
-
-    it('should support mock override with respond', async () => {
-      yesno.mock([
-        createMock({ response: { body: 'a' } }),
-        createMock({ response: { body: 'b' } }),
-        createMock({ response: { body: 'c' } }),
-      ]);
-      yesno
-        .matching({
-          request: {
-            path: '/test',
-          },
-        })
-        .respond({
-          body: 'fizbaz',
-          statusCode: 200,
-        });
-
-      expect(yesno.intercepted()).to.have.lengthOf(0);
-
-      // consumes first mock
-      let response = await requestTestServer();
-      expect(response).to.eql('a');
-      expect(yesno.intercepted()).to.have.lengthOf(1);
-
-      // consumes matched mock
-      response = await requestTestServer({ uri: 'http://localhost/test' });
-      expect(response).to.eql('fizbaz');
-      expect(yesno.intercepted()).to.have.lengthOf(2);
-
-      // consumes third mock
-      response = await requestTestServer();
-      expect(response).to.eql('c');
-      expect(yesno.intercepted()).to.have.lengthOf(3);
     });
 
     it('should reject a request for which no mock has been provided');
@@ -607,6 +578,41 @@ describe('Yesno', () => {
 
         expect(mockedResponse).to.have.property('statusCode', 401);
         expect(mockedResponse).to.have.deep.property('body', body);
+      });
+
+      it('should support mock override with respond', async () => {
+        yesno.mock([
+          createMock({ response: { body: 'a' } }),
+          createMock({ response: { body: 'b' } }),
+          createMock({ response: { body: 'c' } }),
+        ]);
+        yesno
+          .matching({
+            request: {
+              path: '/test',
+            },
+          })
+          .respond({
+            body: 'fizbaz',
+            statusCode: 200,
+          });
+
+        expect(yesno.intercepted()).to.have.lengthOf(0);
+
+        // consumes first mock
+        let response = await requestTestServer();
+        expect(response).to.eql('a');
+        expect(yesno.intercepted()).to.have.lengthOf(1);
+
+        // consumes matched mock
+        response = await requestTestServer({ uri: 'http://localhost/test' });
+        expect(response).to.eql('fizbaz');
+        expect(yesno.intercepted()).to.have.lengthOf(2);
+
+        // consumes third mock
+        response = await requestTestServer();
+        expect(response).to.eql('c');
+        expect(yesno.intercepted()).to.have.lengthOf(3);
       });
     });
   });

--- a/test/unit/yesno.spec.ts
+++ b/test/unit/yesno.spec.ts
@@ -220,6 +220,36 @@ describe('Yesno', () => {
       expect(yesno.intercepted()).to.have.lengthOf(1);
     });
 
+    it('should support out of order mocks', async () => {
+      yesno.mock([createMock(), createMock(), createMock()]);
+      yesno
+        .matching({
+          request: {
+            path: '/test',
+          },
+        })
+        .respond({
+          body: 'fizbaz',
+          statusCode: 200,
+        });
+
+      expect(yesno.intercepted()).to.have.lengthOf(0);
+
+      // consumes first mock
+      let response = await requestTestServer();
+      expect(response).to.eql('foobar');
+
+      // consumes matched mock
+      response = await requestTestServer({ uri: 'http://localhost/test' });
+      expect(response).to.eql('fizbaz');
+      expect(yesno.intercepted()).to.have.lengthOf(2);
+
+      // consumes third mock
+      response = await requestTestServer();
+      expect(response).to.eql('foobar');
+      expect(yesno.intercepted()).to.have.lengthOf(3);
+    });
+
     it('should reject a request for which no mock has been provided');
     it('should handle unexpected errors');
 

--- a/test/unit/yesno.spec.ts
+++ b/test/unit/yesno.spec.ts
@@ -220,8 +220,12 @@ describe('Yesno', () => {
       expect(yesno.intercepted()).to.have.lengthOf(1);
     });
 
-    it('should support out of order mocks', async () => {
-      yesno.mock([createMock(), createMock(), createMock()]);
+    it('should support mock override with respond', async () => {
+      yesno.mock([
+        createMock({ response: { body: 'a' } }),
+        createMock({ response: { body: 'b' } }),
+        createMock({ response: { body: 'c' } }),
+      ]);
       yesno
         .matching({
           request: {
@@ -237,7 +241,8 @@ describe('Yesno', () => {
 
       // consumes first mock
       let response = await requestTestServer();
-      expect(response).to.eql('foobar');
+      expect(response).to.eql('a');
+      expect(yesno.intercepted()).to.have.lengthOf(1);
 
       // consumes matched mock
       response = await requestTestServer({ uri: 'http://localhost/test' });
@@ -246,7 +251,7 @@ describe('Yesno', () => {
 
       // consumes third mock
       response = await requestTestServer();
-      expect(response).to.eql('foobar');
+      expect(response).to.eql('c');
       expect(yesno.intercepted()).to.have.lengthOf(3);
     });
 


### PR DESCRIPTION
I believe that issue #10 was fixed by the addition of respond in feature #66
This adds a test to show matching.respond can be used to handle out of order mocks
