### PR TITLE
add ignore to filteredHttpColletion #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ yesno.matching({ request: { path: '/post' } }) .respond((request) => ({ statusCo
 
 Responses defined in this way take precedence over normally loaded mocks.
 
+### Ignoring matched mocks to proxy requests
+
+Matched requests can ignore the defined mocks and proxy the request to the original host. This provides mixing of live and mocked results. Use the `.ignore()` method on a filtered http collection to disable the mock.
+
+Matching requests set in this way take precedence over all defined and loaded mocks.
+
 ### Restoring HTTP behavior
 
 When we no longer need YesNo to intercept requests we can call `yesno.restore()`. This will completely restore HTTP behavior & clear our mocks. It's advisable to run this after every test.
@@ -242,6 +248,7 @@ To see typedoc generated documentation, click [here](./docs/README.md).
         - [`yesno.matching(filter?: HttpFilter): FilteredHttpCollection`](#yesnomatchingfilter-httpfilter-filteredhttpcollection)
     - [`FilteredHttpCollection`](#filteredhttpcollection-1)
         - [`collection.mocks(): ISerializedHttp[]`](#collectionmocks-iserializedhttp)
+        - [`collection.ignore(): ISerializedHttp`](#collectionignore-iserializedhttp)
         - [`collection.intercepted(): ISerializedHttp[]`](#collectionintercepted-iserializedhttp)
         - [`collection.redact(property: string | string[], redactor: Redactor = () => "*****"): void`](#collectionredactproperty-string--string-redactor-redactor----%22%22-void)
         - [`collection.request(): ISerializedHttp`](#collectionrequest-iserializedhttp)
@@ -254,6 +261,7 @@ To see typedoc generated documentation, click [here](./docs/README.md).
 
 ##### [`FilteredHttpCollection`](#filteredhttpcollection-1)
 - [`collection.mocks(): ISerializedHttp[]`](#collectionmocks-iserializedhttp);
+- [`collection.ignore(): ISerializedHttp`](#collectionignore-iserializedhttp);
 - [`collection.intercepted(): ISerializedHttp[]`](#collectionintercepted-iserializedhttp);
 - [`collection.redact(property: string | string[], redactor: Redactor = () => "*****"): void`](#collectionredactproperty-string--string-redactor-redactor-----void);
 - [`collection.request(): ISerializedHttp`](#collectionrequest-iserializedhttp);
@@ -429,6 +437,12 @@ yesno.matching().response(); // short-cut to get the response from the one inter
 ##### `collection.mocks(): ISerializedHttp[]`
 
 Return the mocks defined within the collection.
+
+##### `collection.ignore(): ISerializedHttp`
+
+Ignore any mocked responses for all matching requests. Matching requests will be proxied to the host.
+
+Any matching requested set in this way take precedence over all defined and loaded mocks.
 
 ##### `collection.intercepted(): ISerializedHttp[]`
 

--- a/docs/classes/_context_.context.md
+++ b/docs/classes/_context_.context.md
@@ -13,6 +13,7 @@ Store the current execution context for YesNo by tracking requests & mocks.
 ### Properties
 
 * [comparatorFn](_context_.context.md#comparatorfn)
+* [ignoresForMatchingRequests](_context_.context.md#ignoresformatchingrequests)
 * [inFlightRequests](_context_.context.md#inflightrequests)
 * [interceptedRequestsCompleted](_context_.context.md#interceptedrequestscompleted)
 * [loadedMocks](_context_.context.md#loadedmocks)
@@ -21,11 +22,14 @@ Store the current execution context for YesNo by tracking requests & mocks.
 
 ### Methods
 
+* [addIgnoreForMatchingRequests](_context_.context.md#addignoreformatchingrequests)
 * [addResponseForMatchingRequests](_context_.context.md#addresponseformatchingrequests)
 * [clear](_context_.context.md#clear)
 * [getMatchingIntercepted](_context_.context.md#getmatchingintercepted)
 * [getMatchingMocks](_context_.context.md#getmatchingmocks)
 * [getResponseDefinedMatching](_context_.context.md#getresponsedefinedmatching)
+* [hasIgnoresDefinedForMatchers](_context_.context.md#hasignoresdefinedformatchers)
+* [hasMatchingIgnore](_context_.context.md#hasmatchingignore)
 * [hasResponsesDefinedForMatchers](_context_.context.md#hasresponsesdefinedformatchers)
 
 ---
@@ -37,6 +41,13 @@ Store the current execution context for YesNo by tracking requests & mocks.
 ###  comparatorFn
 
 **● comparatorFn**: *[ComparatorFn](../modules/_filtering_comparator_.md#comparatorfn)* =  comparatorByUrl
+
+___
+<a id="ignoresformatchingrequests"></a>
+
+###  ignoresForMatchingRequests
+
+**● ignoresForMatchingRequests**: *[IResponseForMatchingRequest](../interfaces/_context_.iresponseformatchingrequest.md)[]* =  []
 
 ___
 <a id="inflightrequests"></a>
@@ -83,6 +94,21 @@ ___
 
 ## Methods
 
+<a id="addignoreformatchingrequests"></a>
+
+###  addIgnoreForMatchingRequests
+
+▸ **addIgnoreForMatchingRequests**(matchingResponse: *[IResponseForMatchingRequest](../interfaces/_context_.iresponseformatchingrequest.md)*): `void`
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| matchingResponse | [IResponseForMatchingRequest](../interfaces/_context_.iresponseformatchingrequest.md) |
+
+**Returns:** `void`
+
+___
 <a id="addresponseformatchingrequests"></a>
 
 ###  addResponseForMatchingRequests
@@ -150,6 +176,30 @@ ___
 | request | [ISerializedRequest](../interfaces/_http_serializer_.iserializedrequest.md) |
 
 **Returns:**  [ISerializedResponse](../interfaces/_http_serializer_.iserializedresponse.md) &#124; `undefined`
+
+___
+<a id="hasignoresdefinedformatchers"></a>
+
+###  hasIgnoresDefinedForMatchers
+
+▸ **hasIgnoresDefinedForMatchers**(): `boolean`
+
+**Returns:** `boolean`
+
+___
+<a id="hasmatchingignore"></a>
+
+###  hasMatchingIgnore
+
+▸ **hasMatchingIgnore**(request: *[ISerializedRequest](../interfaces/_http_serializer_.iserializedrequest.md)*): `boolean`
+
+**Parameters:**
+
+| Name | Type |
+| ------ | ------ |
+| request | [ISerializedRequest](../interfaces/_http_serializer_.iserializedrequest.md) |
+
+**Returns:** `boolean`
 
 ___
 <a id="hasresponsesdefinedformatchers"></a>

--- a/docs/classes/_filtering_collection_.filteredhttpcollection.md
+++ b/docs/classes/_filtering_collection_.filteredhttpcollection.md
@@ -27,6 +27,7 @@ Can filter both intercepted HTTP requests and loaded mocks.
 
 ### Methods
 
+* [ignore](_filtering_collection_.filteredhttpcollection.md#ignore)
 * [intercepted](_filtering_collection_.filteredhttpcollection.md#intercepted)
 * [mocks](_filtering_collection_.filteredhttpcollection.md#mocks)
 * [only](_filtering_collection_.filteredhttpcollection.md#only)
@@ -78,6 +79,19 @@ ___
 
 ## Methods
 
+<a id="ignore"></a>
+
+###  ignore
+
+▸ **ignore**(): `void`
+
+Ignore a mock for all matching requests.
+
+Matching requests defined here take _precedence_ over all mocks and will be proxied.
+
+**Returns:** `void`
+
+___
 <a id="intercepted"></a>
 
 ###  intercepted

--- a/src/context.ts
+++ b/src/context.ts
@@ -93,15 +93,15 @@ export default class Context {
     return firstMatchingResponse;
   }
 
-  public hasIgnoresDefinedForMatchers(): boolean {
-    return !!this.ignoresForMatchingRequests.length;
-  }
-
   public addIgnoreForMatchingRequests(matchingResponse: IResponseForMatchingRequest): void {
     this.ignoresForMatchingRequests.push(matchingResponse);
   }
 
   public hasMatchingIgnore(request: ISerializedRequest): boolean {
+    if (!this.ignoresForMatchingRequests.length) {
+      return false;
+    }
+
     for (const { matcher } of this.ignoresForMatchingRequests) {
       if (match(matcher)({ request })) {
         return true;

--- a/src/context.ts
+++ b/src/context.ts
@@ -43,11 +43,14 @@ export default class Context {
    */
   public inFlightRequests: Array<IInFlightRequest | null> = [];
 
+  public ignoresForMatchingRequests: IResponseForMatchingRequest[] = [];
+
   public responsesForMatchingRequests: IResponseForMatchingRequest[] = [];
 
   public comparatorFn: ComparatorFn = comparatorByUrl;
 
   public clear() {
+    this.ignoresForMatchingRequests = [];
     this.interceptedRequestsCompleted = [];
     this.inFlightRequests = [];
     this.loadedMocks = [];
@@ -88,5 +91,23 @@ export default class Context {
     }
 
     return firstMatchingResponse;
+  }
+
+  public hasIgnoresDefinedForMatchers(): boolean {
+    return !!this.ignoresForMatchingRequests.length;
+  }
+
+  public addIgnoreForMatchingRequests(matchingResponse: IResponseForMatchingRequest): void {
+    this.ignoresForMatchingRequests.push(matchingResponse);
+  }
+
+  public hasMatchingIgnore(request: ISerializedRequest): boolean {
+    for (const { matcher } of this.ignoresForMatchingRequests) {
+      if (match(matcher)({ request })) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/src/filtering/collection.ts
+++ b/src/filtering/collection.ts
@@ -58,6 +58,16 @@ export default class FilteredHttpCollection implements IFiltered {
   }
 
   /**
+   * Ignore a mock for all matching requests.
+   *
+   * Matching requests defined here take _precedence_ over all mocks and will be proxied.
+   */
+  public ignore(): void {
+    const response = { statusCode: 0 }; // will be overridden by proxied response
+    this.ctx.addIgnoreForMatchingRequests({ response, matcher: this.matcher });
+  }
+
+  /**
    * Provide a mock response for all matching requests.
    *
    * Use callback to dynamically generate response per request.

--- a/src/yesno.ts
+++ b/src/yesno.ts
@@ -278,12 +278,13 @@ export class YesNo implements IFiltered {
   private async onIntercept(event: IInterceptEvent): Promise<void> {
     this.recordRequest(event.requestSerializer, event.requestNumber);
 
-    if (
-      (!this.ctx.hasResponsesDefinedForMatchers() && !this.isMode(Mode.Mock)) ||
-      (this.ctx.hasIgnoresDefinedForMatchers() &&
-        this.ctx.hasMatchingIgnore(event.requestSerializer))
-    ) {
+    if (!this.ctx.hasResponsesDefinedForMatchers() && !this.isMode(Mode.Mock)) {
       // No need to mock, send event to its original destination
+      return event.proxy();
+    }
+
+    // proxy requst if ignore is set
+    if (this.ctx.hasMatchingIgnore(event.requestSerializer)) {
       return event.proxy();
     }
 

--- a/src/yesno.ts
+++ b/src/yesno.ts
@@ -278,7 +278,11 @@ export class YesNo implements IFiltered {
   private async onIntercept(event: IInterceptEvent): Promise<void> {
     this.recordRequest(event.requestSerializer, event.requestNumber);
 
-    if (!this.ctx.hasResponsesDefinedForMatchers() && !this.isMode(Mode.Mock)) {
+    if (
+      (!this.ctx.hasResponsesDefinedForMatchers() && !this.isMode(Mode.Mock)) ||
+      (this.ctx.hasIgnoresDefinedForMatchers() &&
+        this.ctx.hasMatchingIgnore(event.requestSerializer))
+    ) {
       // No need to mock, send event to its original destination
       return event.proxy();
     }

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -26,7 +26,7 @@ export function start(port: number = PORT): Promise<ITestServer> {
     debug('Received GET request');
     res.status(headers['x-status-code'] ? parseInt(headers['x-status-code'] as string, 10) : 200);
     res.setHeader('x-test-server-header', 'foo');
-    res.send({ headers, method: 'GET', path: '/get' });
+    res.send({ headers, source: 'server', method: 'GET', path: '/get' });
   });
 
   app.post('/post', ({ headers, body }: express.Request, res: express.Response) => {


### PR DESCRIPTION
This PR adds a .ignore() method on yesno.matching to allow a mocked response to be ignored and have the request proxied to the live host. This allows mixing of live and mocked responses.
I believe that the addition of .respond in a previous PR addresses the second half of this issue to dynamically define mocks.
resolves #48