### PR TITLE
add test for sending headers to the server for form-data requests

### DIFF
--- a/test/unit/yesno.spec.ts
+++ b/test/unit/yesno.spec.ts
@@ -175,6 +175,25 @@ describe('Yesno', () => {
       );
     });
 
+    it('should send headers for form-data', async () => {
+      yesno.spy();
+
+      await rp({
+        formData: {
+          fooBuffer: Buffer.from('foo-buffer'),
+          fooString: 'foobar-string',
+        },
+        headers: { 'x-test-header': 'foo' },
+        method: 'POST',
+        uri: 'http://localhost:3001/post',
+      });
+
+      const intercepted = yesno.intercepted();
+      expect(intercepted).to.have.lengthOf(1);
+      expect(intercepted[0]).to.have.nested.property('request.headers.x-test-header', 'foo');
+      expect(intercepted[0]).to.have.nested.property('response.body.headers.x-test-header', 'foo');
+    });
+
     it('should support binary');
   });
 


### PR DESCRIPTION
This test is to verify the bug of sending request headers to the proxied server for form-data requests.  closes #49 

@ianwsperber I am not able to reproduce the original issue described in the ticket as this test confirms.  Please let me know if there is another path to reproduce the error.