### PR TITLE
add force option to yesno save #8

### DIFF
--- a/docs/classes/_context_.context.md
+++ b/docs/classes/_context_.context.md
@@ -28,7 +28,6 @@ Store the current execution context for YesNo by tracking requests & mocks.
 * [getMatchingIntercepted](_context_.context.md#getmatchingintercepted)
 * [getMatchingMocks](_context_.context.md#getmatchingmocks)
 * [getResponseDefinedMatching](_context_.context.md#getresponsedefinedmatching)
-* [hasIgnoresDefinedForMatchers](_context_.context.md#hasignoresdefinedformatchers)
 * [hasMatchingIgnore](_context_.context.md#hasmatchingignore)
 * [hasResponsesDefinedForMatchers](_context_.context.md#hasresponsesdefinedformatchers)
 
@@ -176,15 +175,6 @@ ___
 | request | [ISerializedRequest](../interfaces/_http_serializer_.iserializedrequest.md) |
 
 **Returns:**  [ISerializedResponse](../interfaces/_http_serializer_.iserializedresponse.md) &#124; `undefined`
-
-___
-<a id="hasignoresdefinedformatchers"></a>
-
-###  hasIgnoresDefinedForMatchers
-
-▸ **hasIgnoresDefinedForMatchers**(): `boolean`
-
-**Returns:** `boolean`
 
 ___
 <a id="hasmatchingignore"></a>

--- a/docs/classes/_yesno_.yesno.md
+++ b/docs/classes/_yesno_.yesno.md
@@ -386,6 +386,8 @@ ___
 
 Save intercepted requests
 
+Normally save is called by the complete method and will only succeed if there are no in-flight requests (i.e. all open requests have completed). However, if for some reason a request will not complete and you need to save the successful requests up to that point, you can set 'force' option to true and call this save method.
+
 **Parameters:**
 
 | Name | Type |

--- a/docs/classes/_yesno_.yesno.md
+++ b/docs/classes/_yesno_.yesno.md
@@ -156,7 +156,13 @@ ___
 
 ### `<Private>` getRecordsToSave
 
-▸ **getRecordsToSave**(): [ISerializedHttp](../interfaces/_http_serializer_.iserializedhttp.md)[]
+▸ **getRecordsToSave**(force?: *`boolean`*): [ISerializedHttp](../interfaces/_http_serializer_.iserializedhttp.md)[]
+
+**Parameters:**
+
+| Name | Type | Default value |
+| ------ | ------ | ------ |
+| `Default value` force | `boolean` | false |
 
 **Returns:** [ISerializedHttp](../interfaces/_http_serializer_.iserializedhttp.md)[]
 

--- a/docs/interfaces/_file_.isaveoptions.md
+++ b/docs/interfaces/_file_.isaveoptions.md
@@ -10,12 +10,21 @@
 
 ### Properties
 
+* [force](_file_.isaveoptions.md#force)
 * [records](_file_.isaveoptions.md#records)
 
 ---
 
 ## Properties
 
+<a id="force"></a>
+
+### `<Optional>` force
+
+**● force**: * `undefined` &#124; `false` &#124; `true`
+*
+
+___
 <a id="records"></a>
 
 ### `<Optional>` records

--- a/src/file.ts
+++ b/src/file.ts
@@ -20,6 +20,7 @@ export interface ISaveFile {
 }
 
 export interface ISaveOptions {
+  force?: boolean;
   records?: ISerializedHttp[];
 }
 

--- a/src/yesno.ts
+++ b/src/yesno.ts
@@ -158,6 +158,11 @@ export class YesNo implements IFiltered {
   /**
    * Save intercepted requests
    *
+   * Normally save is called by the complete method and will only succeed if there are
+   * no in-flight requests (i.e. all open requests have completed). However, if for some
+   * reason a request will not complete and you need to save the successful requests up to
+   * that point, you can set 'force' option to true and call this save method.
+   *
    * @returns Full filename of saved JSON if generated
    */
   public async save(options: file.ISaveOptions & file.IFileOptions): Promise<string | void> {

--- a/src/yesno.ts
+++ b/src/yesno.ts
@@ -161,7 +161,7 @@ export class YesNo implements IFiltered {
    * @returns Full filename of saved JSON if generated
    */
   public async save(options: file.ISaveOptions & file.IFileOptions): Promise<string | void> {
-    options.records = options.records || this.getRecordsToSave();
+    options.records = options.records || this.getRecordsToSave(options.force);
 
     return file.save(options);
   }
@@ -224,10 +224,10 @@ export class YesNo implements IFiltered {
     return env as Mode;
   }
 
-  private getRecordsToSave(): ISerializedHttp[] {
+  private getRecordsToSave(force: boolean = false): ISerializedHttp[] {
     const inFlightRequests = this.ctx.inFlightRequests.filter((x) => x) as IInFlightRequest[];
 
-    if (inFlightRequests.length) {
+    if (inFlightRequests.length && !force) {
       const urls = inFlightRequests
         .map(
           ({ requestSerializer }) => `${requestSerializer.method}${formatUrl(requestSerializer)}`,


### PR DESCRIPTION
Add support for boolean 'force' parameter in yesno save file options.  This allows the recorded records to be saved even if there are still in-flight requests.
closes #8