### PR TITLE
Apply redact to incoming requests #12

### DIFF
--- a/docs/classes/_context_.context.md
+++ b/docs/classes/_context_.context.md
@@ -12,6 +12,7 @@ Store the current execution context for YesNo by tracking requests & mocks.
 
 ### Properties
 
+* [autoRedact](_context_.context.md#autoredact)
 * [comparatorFn](_context_.context.md#comparatorfn)
 * [ignoresForMatchingRequests](_context_.context.md#ignoresformatchingrequests)
 * [inFlightRequests](_context_.context.md#inflightrequests)
@@ -28,7 +29,6 @@ Store the current execution context for YesNo by tracking requests & mocks.
 * [getMatchingIntercepted](_context_.context.md#getmatchingintercepted)
 * [getMatchingMocks](_context_.context.md#getmatchingmocks)
 * [getResponseDefinedMatching](_context_.context.md#getresponsedefinedmatching)
-* [hasIgnoresDefinedForMatchers](_context_.context.md#hasignoresdefinedformatchers)
 * [hasMatchingIgnore](_context_.context.md#hasmatchingignore)
 * [hasResponsesDefinedForMatchers](_context_.context.md#hasresponsesdefinedformatchers)
 
@@ -36,6 +36,16 @@ Store the current execution context for YesNo by tracking requests & mocks.
 
 ## Properties
 
+<a id="autoredact"></a>
+
+###  autoRedact
+
+**● autoRedact**: * [IRedactProp](../interfaces/_context_.iredactprop.md) &#124; `null`
+* =  null
+
+Setting to redact all incoming requests to match redacted mocks
+
+___
 <a id="comparatorfn"></a>
 
 ###  comparatorFn
@@ -176,15 +186,6 @@ ___
 | request | [ISerializedRequest](../interfaces/_http_serializer_.iserializedrequest.md) |
 
 **Returns:**  [ISerializedResponse](../interfaces/_http_serializer_.iserializedresponse.md) &#124; `undefined`
-
-___
-<a id="hasignoresdefinedformatchers"></a>
-
-###  hasIgnoresDefinedForMatchers
-
-▸ **hasIgnoresDefinedForMatchers**(): `boolean`
-
-**Returns:** `boolean`
 
 ___
 <a id="hasmatchingignore"></a>

--- a/docs/interfaces/_context_.iredactprop.md
+++ b/docs/interfaces/_context_.iredactprop.md
@@ -1,0 +1,35 @@
+[yesno-http](../README.md) > ["context"](../modules/_context_.md) > [IRedactProp](../interfaces/_context_.iredactprop.md)
+
+# Interface: IRedactProp
+
+## Hierarchy
+
+**IRedactProp**
+
+## Index
+
+### Properties
+
+* [property](_context_.iredactprop.md#property)
+* [redactor](_context_.iredactprop.md#redactor)
+
+---
+
+## Properties
+
+<a id="property"></a>
+
+###  property
+
+**● property**: * `string` &#124; `string`[]
+*
+
+___
+<a id="redactor"></a>
+
+### `<Optional>` redactor
+
+**● redactor**: *[Redactor](../modules/_filtering_redact_.md#redactor)*
+
+___
+

--- a/docs/modules/_context_.md
+++ b/docs/modules/_context_.md
@@ -11,6 +11,7 @@
 ### Interfaces
 
 * [IInFlightRequest](../interfaces/_context_.iinflightrequest.md)
+* [IRedactProp](../interfaces/_context_.iredactprop.md)
 * [IResponseForMatchingRequest](../interfaces/_context_.iresponseformatchingrequest.md)
 
 ---

--- a/docs/modules/_filtering_redact_.md
+++ b/docs/modules/_filtering_redact_.md
@@ -54,7 +54,11 @@ ___
 
 ▸ **redact**(record: *[ISerializedHttp](../interfaces/_http_serializer_.iserializedhttp.md)*, properties: *`string`[]*, redactor?: *[Redactor](_filtering_redact_.md#redactor)*): [ISerializedHttp](../interfaces/_http_serializer_.iserializedhttp.md)
 
-Redact properties on the matching intercepted records. Note that header names are forced to lower case. Run redact after a request in spy mode to redact the specified properties in the generated mocks to save. Run redact before any requests in mock mode to redact the specified properties on all intercepted requests.
+Redact properties on the matching intercepted records. Note that header names are forced to lower case.
+
+If you want to redact a property in the saved mock file, run yesno.redact after a request has been made in spy mode to redact the specified properties in the intercepted requests to save.
+
+If you want incoming requests in mock mode to be redacted to match the saved mocks, run yesno.redact before any requests have been mode to redact the specified properties on all intercepted requests.
 
 Use a `.` to reference a nested property
 *__todo__*: Benchmark & investigate alternatives

--- a/docs/modules/_filtering_redact_.md
+++ b/docs/modules/_filtering_redact_.md
@@ -56,6 +56,8 @@ ___
 
 Redact properties on the matching intercepted records. Note that header names are forced to lower case.
 
+Run redact after a request in spy mode to redact the specified properties in the generated mocks to save.  Run redact before any requests in mock mode to redact the specified properties on all intercepted requests.
+
 Use a `.` to reference a nested property
 *__todo__*: Benchmark & investigate alternatives
 

--- a/docs/modules/_filtering_redact_.md
+++ b/docs/modules/_filtering_redact_.md
@@ -58,7 +58,7 @@ Redact properties on the matching intercepted records. Note that header names ar
 
 If you want to redact a property in the saved mock file, run yesno.redact after a request has been made in spy mode to redact the specified properties in the intercepted requests to save.
 
-If you want incoming requests in mock mode to be redacted to match the saved mocks, run yesno.redact before any requests have been mode to redact the specified properties on all intercepted requests.
+If you want incoming requests in mock mode to be redacted to match the saved mocks, run yesno.redact before any requests have been made to redact the specified properties on all intercepted requests.
 
 Use a `.` to reference a nested property
 *__todo__*: Benchmark & investigate alternatives

--- a/docs/modules/_filtering_redact_.md
+++ b/docs/modules/_filtering_redact_.md
@@ -54,9 +54,7 @@ ___
 
 ▸ **redact**(record: *[ISerializedHttp](../interfaces/_http_serializer_.iserializedhttp.md)*, properties: *`string`[]*, redactor?: *[Redactor](_filtering_redact_.md#redactor)*): [ISerializedHttp](../interfaces/_http_serializer_.iserializedhttp.md)
 
-Redact properties on the matching intercepted records. Note that header names are forced to lower case.
-
-Run redact after a request in spy mode to redact the specified properties in the generated mocks to save.  Run redact before any requests in mock mode to redact the specified properties on all intercepted requests.
+Redact properties on the matching intercepted records. Note that header names are forced to lower case. Run redact after a request in spy mode to redact the specified properties in the generated mocks to save. Run redact before any requests in mock mode to redact the specified properties on all intercepted requests.
 
 Use a `.` to reference a nested property
 *__todo__*: Benchmark & investigate alternatives

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,7 @@
 import { PartialResponseForRequest } from './filtering/collection';
 import { byUrl as comparatorByUrl, ComparatorFn } from './filtering/comparator';
 import { match, Matcher } from './filtering/matcher';
+import { Redactor } from './filtering/redact';
 import {
   ISerializedHttp,
   ISerializedRequest,
@@ -8,6 +9,11 @@ import {
   RequestSerializer,
 } from './http-serializer';
 import { RecordMode as Mode } from './recording';
+
+export interface IRedactProp {
+  property: string | string[];
+  redactor?: Redactor;
+}
 
 export interface IInFlightRequest {
   startTime: number;
@@ -24,6 +30,11 @@ export interface IResponseForMatchingRequest {
  */
 export default class Context {
   public mode: Mode = Mode.Spy;
+
+  /**
+   * Setting to redact all incoming requests to match redacted mocks
+   */
+  public autoRedact: IRedactProp | null = null;
 
   /**
    * Completed serialized request-response objects. Used for:

--- a/src/filtering/redact.ts
+++ b/src/filtering/redact.ts
@@ -11,9 +11,14 @@ export function defaultRedactor(): string {
 /**
  * Redact properties on the matching intercepted records.
  * Note that header names are forced to lower case.
- * Run redact after a request in spy mode to redact the specified properties in the
- * generated mocks to save.  Run redact before any requests in mock mode to redact
- * the specified properties on all intercepted requests.
+ *
+ * If you want to redact a property in the saved mock file, run yesno.redact after
+ * a request has been made in spy mode to redact the specified properties in the
+ * intercepted requests to save.
+ *
+ * If you want incoming requests in mock mode to be redacted to match the saved mocks,
+ * run yesno.redact before any requests have been mode to redact the specified
+ * properties on all intercepted requests.
  *
  * Use a `.` to reference a nested property
  * @todo Benchmark & investigate alternatives

--- a/src/filtering/redact.ts
+++ b/src/filtering/redact.ts
@@ -11,6 +11,9 @@ export function defaultRedactor(): string {
 /**
  * Redact properties on the matching intercepted records.
  * Note that header names are forced to lower case.
+ * Run redact after a request in spy mode to redact the specified properties in the
+ * generated mocks to save.  Run redact before any requests in mock mode to redact
+ * the specified properties on all intercepted requests.
  *
  * Use a `.` to reference a nested property
  * @todo Benchmark & investigate alternatives

--- a/src/filtering/redact.ts
+++ b/src/filtering/redact.ts
@@ -17,7 +17,7 @@ export function defaultRedactor(): string {
  * intercepted requests to save.
  *
  * If you want incoming requests in mock mode to be redacted to match the saved mocks,
- * run yesno.redact before any requests have been mode to redact the specified
+ * run yesno.redact before any requests have been made to redact the specified
  * properties on all intercepted requests.
  *
  * Use a `.` to reference a nested property

--- a/test/integration/mocks/mock-test-redact-yesno.json
+++ b/test/integration/mocks/mock-test-redact-yesno.json
@@ -1,0 +1,56 @@
+{
+  "records": [
+    {
+      "__duration": 41,
+      "__id": "1",
+      "__timestamp": 1594314369237,
+      "__version": "1.0.0",
+      "request": {
+        "body": {
+          "password": "*****",
+          "username": "hulkhoganhero"
+        },
+        "headers": {
+          "x-status-code": 200,
+          "host": "localhost:3001",
+          "accept": "application/json",
+          "content-type": "application/json",
+          "content-length": 48
+        },
+        "host": "localhost",
+        "method": "POST",
+        "path": "/post",
+        "port": 3001,
+        "protocol": "http"
+      },
+      "response": {
+        "body": {
+          "headers": {
+            "x-status-code": "200",
+            "host": "localhost:3001",
+            "accept": "application/json",
+            "content-type": "application/json",
+            "content-length": "48",
+            "connection": "close"
+          },
+          "body": {
+            "password": "secret",
+            "username": "hulkhoganhero"
+          },
+          "method": "POST",
+          "path": "/post"
+        },
+        "headers": {
+          "x-powered-by": "Express",
+          "x-test-server-header": "foo",
+          "content-type": "application/json; charset=utf-8",
+          "content-length": "251",
+          "etag": "W/\"fb-kMrRfN5TqT3Sw6VGbMDQrSt8J4E\"",
+          "date": "Thu, 09 Jul 2020 17:06:09 GMT",
+          "connection": "close"
+        },
+        "statusCode": 200
+      }
+    }
+  ]
+}

--- a/test/integration/yesno.spec.ts
+++ b/test/integration/yesno.spec.ts
@@ -159,6 +159,32 @@ describe('yesno', () => {
         'secret',
       );
     });
+
+    it('should allow redacting intercepted requests as well', async () => {
+      // run redact before the request to redact the intercepted request
+      const toRedact = 'request.body.password';
+      yesno.redact(toRedact);
+
+      const mocks = await yesno.load({
+        filename: `${path.join(__dirname, 'mocks')}/mock-test-redact-yesno.json`,
+      });
+      yesno.mock(mocks);
+
+      await rp.post({
+        body: {
+          password: 'secret',
+          username: 'hulkhoganhero',
+        },
+        headers: {
+          'x-status-code': 200,
+        },
+        json: true,
+        uri: 'http://localhost:3001/post',
+      });
+
+      const intercepted = yesno.intercepted();
+      expect(intercepted[0]).to.have.nested.property(toRedact, '*****');
+    });
   });
 
   describe('mock mode', () => {


### PR DESCRIPTION
Add ability to apply redact to all incoming requests in mock mode to match saved mocks that were redacted.
closes #12