### PR TITLE
initial support for mockRule

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -9,6 +9,7 @@ import {
   RequestSerializer,
 } from './http-serializer';
 import { RecordMode as Mode } from './recording';
+import Rule from './rule';
 
 export interface IRedactProp {
   property: string | string[];
@@ -30,6 +31,7 @@ export interface IResponseForMatchingRequest {
  */
 export default class Context {
   public mode: Mode = Mode.Spy;
+  public rules: Rule[] = [];
 
   /**
    * Setting to redact all incoming requests to match redacted mocks

--- a/src/filtering/matcher.ts
+++ b/src/filtering/matcher.ts
@@ -26,6 +26,8 @@ export type UnsafeMatchFn = (serialized: ISerializedRequestResponseToMatch) => b
 
 export type Matcher = ISerializedHttpPartialDeepMatch | MatchFn;
 
+export type HttpFilter = string | RegExp | ISerializedHttpPartialDeepMatch | MatchFn;
+
 export const EMPTY_RESPONSE = { body: {}, headers: {}, statusCode: 0 };
 
 /**

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -1,0 +1,48 @@
+import Context from './context';
+import { YesNoError } from './errors';
+import { Matcher } from './filtering/matcher';
+import MockResponse from './mock-response';
+
+export enum MockMode {
+  Live = 'LIVE',
+  Record = 'RECORD',
+  Respond = 'RESPOND',
+}
+
+export interface IRule {
+  matcher: Matcher;
+  mock?: MockResponse;
+  mode: MockMode;
+}
+
+export interface IRuleParams {
+  context: Context;
+  matcher: Matcher;
+}
+
+export default class Rule implements IRule {
+  public matcher: Matcher;
+  public mock?: MockResponse;
+  public mode: MockMode;
+  private readonly ctx: Context;
+
+  constructor({ context, matcher = {} }: IRuleParams) {
+    this.ctx = context;
+    this.matcher = matcher;
+    this.mode = MockMode.Record;
+  }
+
+  /**
+   * Set the rule mode to 'record'
+   */
+  public record(): IRule {
+    const index = this.ctx.rules.length - 1;
+
+    if (index < 0) {
+      throw new YesNoError('No rules have been defined yet');
+    }
+
+    this.ctx.rules[index].mode = MockMode.Record;
+    return this.ctx.rules[index];
+  }
+}


### PR DESCRIPTION
This is the initial framework for adding mockRule support.  The existing behavior is unchanged if no rules are defined.  Future PRs will implement the rule types and modes.