### PR TITLE
Fallback on suite test globals if none provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,11 +276,11 @@ A utility method for creating test definitions instrumented with `yesno.recordin
 
 ##### `IRecordableTest`
 
-`options.test: (name: string, test: () => Promise<any>) => any`: A test function, such as `jest.test` or `mocha.it` which accepts a name and test definition. The test may either be synchronous or return a promise.
-
-`options.it: (name: string, test: () => Promise<any>) => any`: Alias for `options.test`
-
 `options.dir: string`: Directory to use for recording
+
+`options.test?: (name: string, test: () => Promise<any>) => any`: A test function, such as `jest.test` or `mocha.it` which accepts a name and test definition. The test may either be synchronous or return a promise. If no parameter is provided for `test` or `it`, falls back to the global `test` or `it`.
+
+`options.it?: (name: string, test: () => Promise<any>) => any`: Alias for `options.test`
 
 `options.prefix?: string`: _Optional_. Prefix to use for all fixtures. Useful to prevent conflicts with similarly named tests in other files.
 

--- a/src/yesno.ts
+++ b/src/yesno.ts
@@ -119,7 +119,7 @@ export class YesNo implements IFiltered {
    * Create a test function that will wrap its provided test in a recording.
    */
   public test({ it, test, dir, prefix }: IRecordableTest): GenericTestFunction {
-    const runTest = test || it;
+    const runTest = test || it || global.test || global.it;
 
     if (!runTest) {
       throw new YesNoError('Missing "test" or "it" test function');


### PR DESCRIPTION
Small enhancement to fallback to test suite globals if none is provided. Should help with usability.